### PR TITLE
feat: migrate Component.svelte to Svelte 5 runes + v1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "bb-component-SuperButton",
-  "version": "1.8.7",
+  "version": "1.9.0",
   "description": "A Button Component for Budibase",
   "license": "MIT",
   "author": "Michael Poirazi",

--- a/src/Component.svelte
+++ b/src/Component.svelte
@@ -5,15 +5,30 @@
   const { styleable } = getContext("sdk");
   const component = getContext("component");
 
-  $: $component.styles = {
-    ...$component.styles,
-    normal: {
-      ...$component.styles.normal,
-      "max-width": "fit-content",
-    },
-  };
+  // Svelte 5 runes: ensure max-width: fit-content is always applied.
+  // Guarded update prevents infinite loop when the store reacts to our own change.
+  $effect(() => {
+    const current = $component;
+    if (!current?.styles) return;
+
+    if (current.styles?.normal?.["max-width"] === "fit-content") return;
+
+    component.update((c) => ({
+      ...c,
+      styles: {
+        ...c.styles,
+        normal: {
+          ...c.styles?.normal,
+          "max-width": "fit-content",
+        },
+      },
+    }));
+  });
+
+  // Forward all props using runes ($$props still works due to compatibility mode)
+  let props = $props();
 </script>
 
 <div use:styleable={$component.styles}>
-  <SuperButton {...$$props} />
+  <SuperButton {...props} />
 </div>


### PR DESCRIPTION
## Summary

- Migrates `src/Component.svelte` from legacy Svelte 4 reactive syntax (`$:`) to Svelte 5 runes
- Replaces the reactive style override with a guarded `$effect()` + store `.update()`
- Switches prop forwarding to use `$props()`
- Bumps minor version from `1.8.7` → `1.9.0`

## Changes

- `src/Component.svelte`: Full runes migration (no behavior change)
- `package.json`: Version bump to 1.9.0

## Testing

- Build succeeds with no new errors
- Existing Budibase component behavior preserved (the `max-width: fit-content` override and full prop passthrough to SuperButton)

## Release

On merge to `main`, the existing Release workflow will automatically:
- Build the production bundle
- Create a GitHub Release `v1.9.0` with the `.tar.gz` artifact